### PR TITLE
ci(release): uses the lint action in the release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,20 +12,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v4
-        with:
-          configFile: .commitlintrc.yml
-      - name: Download actionlint
-        id: get_actionlint
-        shell: bash
-        run: |
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          export LOCAL_BIN="$HOME/.local/bin"
-          mkdir -p "$LOCAL_BIN"
-          mv actionlint "$LOCAL_BIN"
-          echo "$LOCAL_BIN" >> "$GITHUB_PATH"
-      - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.0
+      - uses: ./lint
   release:
     needs:
       - lint


### PR DESCRIPTION
This uses the shared lint action (self) during the release process.