### PR TITLE
fix(lint): improve how actionlint install

### DIFF
--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -12,14 +12,8 @@ runs:
         if [ -f package-lock.json ]; then
           npm ci
         fi
-    - name: Download actionlint
-      id: get_actionlint
-      shell: bash
-      run: |
-        bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-        export LOCAL_BIN="$HOME/.local/bin"
-        mkdir -p "$LOCAL_BIN"
-        mv actionlint "$LOCAL_BIN"
-        echo "$LOCAL_BIN" >> "$GITHUB_PATH"
+    - uses: KeisukeYamashita/setup-release@v1.0.2
+      with:
+        repository: rhysd/actionlint
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.0


### PR DESCRIPTION
We will now use KeisukeYamashita/setup-release to pull the latest
actionlint release and install it.