### PR TITLE
feat(test): adds test action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,14 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./lint
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./test
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
   action-test:
     name: Action test
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jobs:
         uses: open-turo/actions-gha/lint@v1
 ```
 
-### action: [`node-check-dist`](./node-check-dist)
+### action: [`check-build`](./check-build)
 
 ```yaml
 jobs:
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Dist check
-        uses: open-turo/actions-gha/node-check-dist@v1
+        uses: open-turo/actions-gha/check-build@v1
 ```
 
 ### action: [`release`](./release)
@@ -54,6 +54,18 @@ jobs:
           dry_run: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### action: [`test`](./test)
+
+```yaml
+jobs:
+  test:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Test
+        uses: open-turo/actions-gha/test@v1
 ```
 
 <!-- Links: -->

--- a/check-build/README.md
+++ b/check-build/README.md
@@ -1,4 +1,4 @@
-# GitHub Action Node Check Dist
+# GitHub Action Check Node Build
 
 GitHub Action runs checks to see if the code has changed without running a build.
 
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Dist check
-        uses: open-turo/actions-gha/node-check-dist@v1
+        uses: open-turo/actions-gha/check-build@v1
 ```
 
 ## Dist check

--- a/check-build/action.yaml
+++ b/check-build/action.yaml
@@ -1,5 +1,5 @@
-name: "GitHub Action Lint"
-description: "Lints GitHub Actions"
+name: "Check node build"
+description: "Checks whether node has been built and committed into the ./dist directory"
 inputs:
   github-token:
     required: true
@@ -46,7 +46,6 @@ runs:
           git commit -a --amend --no-edit
           ```
           This will add those changes to your last commit.  Push that to your PR.
-
     - name: Delete instructions comment
       if: success() && steps.fc.outputs.comment-id != ''
       uses: jungwinter/comment@v1

--- a/lint/README.md
+++ b/lint/README.md
@@ -22,10 +22,13 @@ This action runs the following lint checks:
 
 - [wagoid/commitlint-github-action](https://github.com/wagoid/commitlint-github-action)
 - [pre-commit/action](https://github.com/pre-commit/action)
+- [check-build](../check-build) - if the action is `node`, this checks that build has been run and committed.
 
 ## Notes
 
-- If the repository has a `package-lock.json`, it will execute `npm ci` before running the `pre-commit` step.
+- If the repository has a `package-lock.json`
+  - It will execute `npm ci` before running the `pre-commit` step.
+  - It will run the `check-build` action.
 - `actionlint` will be installed and in the path to ensure that https://github.com/rhysd/actionlint can be run directly.
 - This expects that `.commitlintrc.yml` will be present to enforce [`conventional-commit`](https://github.com/wagoid/commitlint-github-action).
 - Checkout must have history to ensure that commit message linting works.

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -1,19 +1,28 @@
 name: "GitHub Action Lint"
 description: "Lints GitHub Actions"
+inputs:
+  github-token:
+    required: true
+    description: "GitHub token that can create/delete comments. Usually - 'secrets.GITHUB_TOKEN'"
 runs:
   using: composite
   steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - uses: wagoid/commitlint-github-action@v4
       with:
         configFile: .commitlintrc.yml
     - name: Run npm ci if needed
+      if: hashFiles('package-lock.json') != ''
       shell: bash
-      run: |
-        if [ -f package-lock.json ]; then
-          npm ci
-        fi
+      run: npm ci
     - uses: KeisukeYamashita/setup-release@v1.0.2
       with:
         repository: rhysd/actionlint
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.0
+    - uses: open-turo/actions-gha/check-build@v1
+      if: hashFiles('package-lock.json') != ''
+      with:
+        github-token: ${{ inputs.github-token }}

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,24 @@
+# GitHub Action Test
+
+GitHub Action runs tests appropriate for this action.
+
+## Usage
+
+```yaml
+jobs:
+  test:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Test
+        uses: open-turo/actions-gha/test@v1
+```
+
+## Test
+
+For node based actions, it will run:
+
+```shell
+npm ci
+npm test -- --coverage
+```

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -1,0 +1,20 @@
+name: "GitHub Action: Test"
+description: "Tests GitHub Actions"
+inputs:
+  github-token:
+    required: true
+    description: "GitHub token passed to coveralls. Usually - 'secrets.GITHUB_TOKEN'. Coveralls uses this token to verify the posted coverage data on the repo and create a new check based on the results. It is built into Github Actions and does not need to be manually specified in your secrets store."
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v2
+    - name: Test node
+      if: hashFiles('package-lock.json') != ''
+      shell: bash
+      run: |
+        npm ci
+        npm test -- --coverage
+    - uses: coverallsapp/github-action@master
+      if: hashFiles('package-lock.json') != ''
+      with:
+        github-token: ${{ inputs.github-token }}


### PR DESCRIPTION
This adds a new `test` action that will test `node` based actions.  This also shifts `check-build`
to happen as part of lint.

## Usage

```yaml
jobs:
  test:
    steps:
      - name: Checkout
        uses: actions/checkout@v2
      - name: Test
        uses: open-turo/actions-gha/test@v1
```

For node based actions, it will run:

```shell
npm ci
npm test -- --coverage
```