### PR TITLE
fix(lint): do not enforce comment linting for dependabot

### DIFF
--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -16,6 +16,7 @@ runs:
       with:
         fetch-depth: 0
     - uses: wagoid/commitlint-github-action@v4
+      if: (github.actor!= 'dependabot[bot]') && (contains(github.head_ref, 'dependabot/github_actions/') == false)
       with:
         configFile: .commitlintrc.yml
     - name: Run npm ci if needed


### PR DESCRIPTION
Dependabot commit messages have bodies that are too long due to URLs.

This removes the check for commit messages when it is a dependabot commit.