### PR TITLE
fix(check-build): checkbuild should only add comments to PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,7 @@ jobs:
       - uses: ./test
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
   action-test:
     name: Action test
     runs-on: ubuntu-latest

--- a/check-build/action.yaml
+++ b/check-build/action.yaml
@@ -26,14 +26,14 @@ runs:
         fi
     - name: Check for run instructions
       uses: peter-evans/find-comment@v1
-      if: success() || failure()
+      if: github.event_name == 'pull_request' && (success() || failure())
       id: fc
       with:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: "github-actions[bot]"
         body-includes: "npm run prepare"
     - name: Create instructions comment
-      if: failure() && steps.fc.outputs.comment-id == ''
+      if: github.event_name == 'pull_request' && failure() && steps.fc.outputs.comment-id == ''
       uses: peter-evans/create-or-update-comment@v1
       with:
         issue-number: ${{ github.event.pull_request.number }}
@@ -47,7 +47,7 @@ runs:
           ```
           This will add those changes to your last commit.  Push that to your PR.
     - name: Delete instructions comment
-      if: success() && steps.fc.outputs.comment-id != ''
+      if: github.event_name == 'pull_request' && success() && steps.fc.outputs.comment-id != ''
       uses: jungwinter/comment@v1
       with:
         type: delete


### PR DESCRIPTION
The `check-build` action attempts to create a comment letting people know that the build isn't
correct and what they need to do to correct it.  This ensures those steps do not run against pushes
into master.

fixes #16