### PR TITLE
fix: install actionlint via bash

### DIFF
--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -20,10 +20,15 @@ runs:
       if: hashFiles('package-lock.json') != ''
       shell: bash
       run: npm ci
-    - name: Install actionlint
-      uses: KeisukeYamashita/setup-release@v1.0.2
-      with:
-        repository: rhysd/actionlint
+    - name: Install actionlint via bash
+      shell: bash
+      run: |
+        bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        actionLintVersion=`./actionlint -version | sed -n 1p`
+        destDir="/opt/hostedtoolcache/release/$actionLintVersion"
+        mkdir -p "$destDir"
+        mv actionlint "$destDir"
+        echo "$destDir" >> "$GITHUB_PATH"
     - name: Pre-commit
       uses: open-turo/action-pre-commit@v1
     - name: Check build


### PR DESCRIPTION
Trying this since `KeisukeYamashita/setup-release` uses node 12, is the source of "Node.js 12 actions are deprecated" warnings coming from GitHub, and hasn't had a change in two years. This as one alternative we can consider to resolve those deprecation warnings.