### PR TITLE
fix: use v2 for coveralls action

### DIFF
--- a/test/action.yaml
+++ b/test/action.yaml
@@ -21,7 +21,7 @@ runs:
         npm ci
         npm test -- --coverage
     - name: Coveralls
-      uses: coverallsapp/github-action@master
+      uses: coverallsapp/github-action@v2
       if: hashFiles('package-lock.json') != ''
       with:
         github-token: ${{ inputs.github-token }}


### PR DESCRIPTION

**Description**

We were pointing to master, which hasn't been updated in a while sicne they moved to main as defaultt branch

The action is failing in repos that have multiple packages. See example in https://github.com/open-turo/actions-release/actions/runs/6004948686/job/16286646454

By updating to v2 of the action they should autodiscover all coverage files.

**Changes**

* fix: use v2 for coveralls action

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
