### PR TITLE
feat(release): use open-turo/actions-release for semantic release

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["github>open-turo/renovate-config#v1"]
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,4 +40,7 @@ jobs:
       - name: Release
         uses: ./release
         with:
+          checkout-repo: false
           dry-run: true
+          extra-plugins: |
+            @open-turo/semantic-release-config

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,17 @@ on:
     branches: [main]
 
 jobs:
+  release-notes:
+    name: Release notes preview
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
+    steps:
+      - uses: open-turo/actions-release/release-notes-preview@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          extra-plugins: |
+            @open-turo/semantic-release-config
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,7 @@
 name: CI
 
 on:
-  pull_request:
-    branches: [main]
+  push:
 
 jobs:
   release-notes:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,3 +32,5 @@ jobs:
         uses: ./release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          extra-plugins: |
+            @open-turo/semantic-release-config

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -1,0 +1,23 @@
+name: Update dependencies
+concurrency: update-dependencies
+
+on:
+  schedule:
+    # Every day at midnight
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+  issue_comment:
+    types:
+      - edited
+  pull_request:
+    types:
+      - edited
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    name: Update dependencies
+    steps:
+      - uses: open-turo/action-renovate@v1
+        with:
+          github-token: ${{ secrets.OPEN_TURO_GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,26 +1,29 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0 # Use the ref you want to point at
+    rev: v4.4.0
     hooks:
       - id: check-json
       - id: check-yaml
-      - id: pretty-format-json
-        args:
-          - --autofix
       - id: end-of-file-fixer
+        exclude: dist
       - id: trailing-whitespace
+        exclude: |
+          (?x)^(
+            test/__snapshots__/.*snap|
+            test/.*/__snapshots__/.*snap
+          )$
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.5.1
+    rev: v3.0.0
     hooks:
       - id: prettier
         stages: [commit]
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v8.0.0
+    rev: v9.5.0
     hooks:
       - id: commitlint
         stages: [commit-msg]
         additional_dependencies: ["@open-turo/commitlint-config-conventional"]
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.6.8
+    rev: v1.6.25
     hooks:
       - id: actionlint

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,15 +1,3 @@
 {
-  "branches": [
-    "main",
-    {
-      "channel": "next",
-      "name": "(f|b|c)/*",
-      "prerelease": "beta-<%= (/^\\w+-\\d+/.exec(name.substr(2)) || [])[0] %>"
-    }
-  ],
-  "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
-    "@semantic-release/github"
-  ]
+  "extends": "@open-turo/semantic-release-config"
 }

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -22,13 +22,13 @@ inputs:
 outputs:
   new-release-published:
     description: Whether a new release was published
-    value: ${{ steps.release.outputs.new_release_published }}
+    value: ${{ steps.release.outputs.new-release-published }}
   new-release-version:
     description: Version of the new release
-    value: ${{ steps.release.outputs.new_release_version }}
+    value: ${{ steps.release.outputs.new-release-version }}
   new-release-major-version:
     description: Major version of the new release
-    value: ${{ steps.release.outputs.new_release_major_version }}
+    value: ${{ steps.release.outputs.new-release-major-version }}
 runs:
   using: composite
   steps:
@@ -37,29 +37,22 @@ runs:
       if: inputs.checkout-repo
       with:
         fetch-depth: 0
-    # TODO(shakefu): This is a work around while we resolve the compatibility
-    # issue with cycjimmy's action and SemVer >20
-    - uses: open-turo/action-setup-tools@v1
-    # Install open-turo semantic release config
-    - name: Install dependencies
-      shell: bash
-      run: npm install '@open-turo/semantic-release-config@^1.4.0' --no-save
     - name: Semantic release
       id: release
-      uses: cycjimmy/semantic-release-action@v3
+      uses: open-turo/actions-release/semantic-release@v2
       env:
         GITHUB_TOKEN: ${{ inputs.github-token || env.GITHUB_TOKEN }}
       with:
-        dry_run: ${{ inputs.dry-run }}
-        extra_plugins: ${{ inputs.extra-plugins }}
+        dry-run: ${{ inputs.dry-run }}
+        extra-plugins: ${{ inputs.extra-plugins }}
     - name: Fetch tags
-      if: steps.release.outputs.new_release_published == 'true'
+      if: steps.release.outputs.new-release-published == 'true'
       shell: bash
       run: |
         git fetch --tags
         git clean -fd
     - name: Major branch
-      if: steps.release.outputs.new_release_published == 'true'
+      if: steps.release.outputs.new-release-published == 'true'
       uses: open-turo/action-major-release@v1
       with:
-        major-version: ${{ steps.release.outputs.new_release_major_version }}
+        major-version: ${{ steps.release.outputs.new-release-major-version }}


### PR DESCRIPTION

**Description**

Use the open-turo semantic-release action https://github.com/open-turo/actions-release/tree/main/semantic-release

Trigger a major release to be completely safe and avoid breaking any existing consumer. Things should work fine, but we have some Node repos that are using the old version as well.

This PR also adds renovatebot and updates other dotfiles / adds some missing features like release notes preview

**Changes**

* feat(release): use open-turo/actions-release for semantic release
* ci: add release notes preview action
* build: use open-turo release config and update some pre-commit hooks
* ci: replace dependabot with renovatebot

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
