### PR TITLE
feat(lint): lint now checks release notes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,26 +1,15 @@
 name: CI
 
 on:
-  push:
+  pull_request: {}
 
 jobs:
-  release-notes:
-    name: Release notes preview
-    runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main'
-    steps:
-      - uses: open-turo/actions-release/release-notes-preview@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          extra-plugins: |
-            @open-turo/semantic-release-config
-
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Lint
@@ -33,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Test
         uses: ./test
         with:
@@ -44,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Lint
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Release

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,10 @@ repos:
     rev: v1.6.25
     hooks:
       - id: actionlint
+  - repo: local
+    hooks:
+      - id: update-action-readme
+        name: update-action-readme
+        entry: ./script/update-action-readme
+        language: script
+        files: '.*/action\.yaml$'

--- a/check-build/README.md
+++ b/check-build/README.md
@@ -17,16 +17,29 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-## Inputs
-
-| parameter    | description                                                               | required | default |
-| ------------ | ------------------------------------------------------------------------- | -------- | ------- |
-| github-token | GitHub token that can create/delete comments. e.g. 'secrets.GITHUB_TOKEN' | `true`   |         |
-
-## Runs
-
-This action is an `composite` action.
-
 ## Dist check
 
 Runs `npm run prepare` and checks to see if there are uncommitted changes.
+
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs -->
+## Inputs
+
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| github-token | GitHub token that can create/delete comments. e.g. 'secrets.GITHUB_TOKEN' | `true` |  |
+<!-- action-docs-inputs -->
+
+<!-- action-docs-outputs -->
+
+<!-- action-docs-outputs -->
+
+<!-- action-docs-runs -->
+## Runs
+
+This action is a `composite` action.
+<!-- action-docs-runs -->
+
+<!-- action-docs-usage  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->

--- a/lint/README.md
+++ b/lint/README.md
@@ -1,8 +1,12 @@
 # GitHub Action Lint
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-description -->
 ## Description
 
 GitHub Action that runs lint on a GitHub Action
+<!-- action-docs-description -->
+<!-- prettier-ignore-end -->
 
 ## Usage
 
@@ -15,17 +19,6 @@ jobs:
           ## example value for github-token provided below
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
-
-## Inputs
-
-| parameter     | description                                                                    | required | default |
-| ------------- | ------------------------------------------------------------------------------ | -------- | ------- |
-| checkout-repo | Perform checkout as first step of action                                       | `false`  | true    |
-| github-token  | GitHub token that can create/delete comments. Usually - 'secrets.GITHUB_TOKEN' | `true`   |         |
-
-## Runs
-
-This action is an `composite` action.
 
 ## Lint Checks
 
@@ -41,3 +34,27 @@ This action runs the following lint checks:
   - It will execute `npm ci` before running the `pre-commit` step.
   - It will run the `check-build` action.
 - This expects that `.commitlintrc.yaml` will be present at the root level of the consumer repository to enforce [`conventional-commit`](https://github.com/wagoid/commitlint-github-action).
+
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs -->
+## Inputs
+
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| checkout-repo | Perform checkout as first step of action | `false` | true |
+| github-token | GitHub token that can create/delete comments. Usually - 'secrets.GITHUB_TOKEN' | `true` |  |
+<!-- action-docs-inputs -->
+
+<!-- action-docs-outputs -->
+
+<!-- action-docs-outputs -->
+
+<!-- action-docs-runs -->
+## Runs
+
+This action is a `composite` action.
+<!-- action-docs-runs -->
+
+<!-- action-docs-usage  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -12,10 +12,13 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       if: inputs.checkout-repo == 'true'
       with:
         fetch-depth: 0
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
     - name: Run npm ci if needed
       if: hashFiles('package-lock.json') != ''
       shell: bash
@@ -31,3 +34,6 @@ runs:
       if: hashFiles('package-lock.json') != ''
       with:
         github-token: ${{ inputs.github-token }}
+    - name: Check release notes on pull_request
+      if: github.event_name == 'pull_request'
+      uses: open-turo/actions-release/lint-release-notes@v4

--- a/release/README.md
+++ b/release/README.md
@@ -23,28 +23,39 @@ steps:
 ```
 
 **IMPORTANT**: `GITHUB_TOKEN` does not have the required permissions to operate on protected branches.
-If you are using this action for protected branches, replace `GITHUB_TOKEN` with [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). If using the `@semantic-release/git` plugin for protected branches, avoid persisting credentials as part of `actions/checkout@v3` by setting the parameter `persist-credentials: false`. This credential does not have the required permission to operate on protected branches.
+If you are using this action for protected branches, replace `GITHUB_TOKEN` with [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). If using the `@semantic-release/git` plugin for protected branches, avoid persisting credentials as part of `actions/checkout@v4` by setting the parameter `persist-credentials: false`. This credential does not have the required permission to operate on protected branches.
 
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs -->
 ## Inputs
 
-| parameter     | description                                                                                                                                                               | required | default                            |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ---------------------------------- |
-| checkout-repo | Perform checkout as first step of action                                                                                                                                  | `false`  | true                               |
-| dry-run       | Whether to run semantic release in `dry-run` mode. It will override the `dryRun` attribute in your configuration file                                                     | `false`  |                                    |
-| extra-plugins | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer. Defaults to install @open-turo/semantic-release-config. | `false`  | @open-turo/semantic-release-config |
-| github-token  | GitHub token that can create/delete comments. e.g. 'secrets.GITHUB_TOKEN'                                                                                                 | `false`  |                                    |
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| checkout-repo | Perform checkout as first step of action | `false` | true |
+| dry-run | Whether to run semantic release in `dry-run` mode. It will override the `dryRun` attribute in your configuration file | `false` |  |
+| extra-plugins | Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config. | `false` | @open-turo/semantic-release-config  |
+| github-token | GitHub token that can create/delete comments. e.g.  'secrets.GITHUB_TOKEN' | `false` |  |
+<!-- action-docs-inputs -->
 
+<!-- action-docs-outputs -->
 ## Outputs
 
-| parameter                 | description                         |
-| ------------------------- | ----------------------------------- |
-| new-release-published     | Whether a new release was published |
-| new-release-version       | Version of the new release          |
-| new-release-major-version | Major version of the new release    |
+| parameter | description |
+| --- | --- |
+| new-release-published | Whether a new release was published |
+| new-release-version | Version of the new release |
+| new-release-major-version | Major version of the new release |
+<!-- action-docs-outputs -->
 
+<!-- action-docs-runs -->
 ## Runs
 
-This action is an `composite` action.
+This action is a `composite` action.
+<!-- action-docs-runs -->
+
+<!-- action-docs-usage  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->
 
 ## Additional Examples
 

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -33,13 +33,13 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       if: inputs.checkout-repo == 'true'
       with:
         fetch-depth: 0
     - name: Semantic release
       id: release
-      uses: open-turo/actions-release/semantic-release@v2
+      uses: open-turo/actions-release/semantic-release@v4
       env:
         GITHUB_TOKEN: ${{ inputs.github-token || env.GITHUB_TOKEN }}
       with:

--- a/script/update-action-readme
+++ b/script/update-action-readme
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+for i in $*; do
+  # ignore if the file does not end with /action.yaml
+  if [[ "$i" != *"/action.yaml" ]]; then
+    echo "skipping: ${i}"
+    continue
+  fi
+  readme_file=$(dirname "$i")/README.md
+  echo "npx action-docs --no-banner -a "${i}" --update-readme "${readme_file}""
+  npx action-docs --no-banner -a "${i}" --update-readme "${readme_file}"
+done

--- a/test/README.md
+++ b/test/README.md
@@ -16,27 +16,30 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-## Inputs
-
-| parameter     | description                                                                                                                                                                                                                                                                                          | required | default |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
-| checkout-repo | Perform checkout as first step of action                                                                                                                                                                                                                                                             | `false`  | true    |
-| github-token  | GitHub token passed to coveralls. Usually - 'secrets.GITHUB_TOKEN'. Coveralls uses this token to verify the posted coverage data on the consumer repo and create a new check based on the results. It is built into Github Actions and does not need to be manually specified in your secrets store. | `true`   |         |
-
-## Runs
-
-This action is an `composite` action.
-
-## Test
-
-For node based actions, it will run:
-
-```shell
-npm ci
-npm test -- --coverage
-coveralls
-```
-
 ## Notes
 
 - By default, this action will perform actions/checkout as its first step.
+
+<!-- prettier-ignore-start -->
+<!-- action-docs-inputs -->
+## Inputs
+
+| parameter | description | required | default |
+| --- | --- | --- | --- |
+| checkout-repo | Perform checkout as first step of action | `false` | true |
+| github-token | GitHub token passed to coveralls. Usually - 'secrets.GITHUB_TOKEN'. Coveralls uses this token to verify the posted coverage data on the consumer repo and create a new check based on the results. It is built into Github Actions and does not need to be manually specified in your secrets store. | `true` |  |
+<!-- action-docs-inputs -->
+
+<!-- action-docs-outputs -->
+
+<!-- action-docs-outputs -->
+
+<!-- action-docs-runs -->
+## Runs
+
+This action is a `composite` action.
+<!-- action-docs-runs -->
+
+<!-- action-docs-usage  -->
+<!-- action-docs-usage -->
+<!-- prettier-ignore-end -->

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -12,7 +12,7 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       if: inputs.checkout-repo == 'true'
     - name: Test node
       if: hashFiles('package-lock.json') != ''


### PR DESCRIPTION

**Description**

This adds support for checking release notes to lint.

Also, we have updated how the action READMEs are generated.  They now
use a pre-commit hook to call action-docs.



**Changes**

* feat(lint): lint now checks release notes

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
