### PR TITLE
ci: remove pinned semantic-release-config version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           semantic-release-extra-plugins: |
-            @open-turo/semantic-release-config@4.0.3
+            @open-turo/semantic-release-config
 
   test:
     name: Test
@@ -45,4 +45,4 @@ jobs:
           checkout-repo: false
           dry-run: true
           extra-plugins: |
-            @open-turo/semantic-release-config@4.0.3
+            @open-turo/semantic-release-config

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,4 +34,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           extra-plugins: |
-            @open-turo/semantic-release-config@4.0.3
+            @open-turo/semantic-release-config


### PR DESCRIPTION

**Description**

This is no longer needed. Moving forward, in `actions-release` we'll have a better way to handle major updates of semantic-release-config



**Changes**

* ci: remove pinned semantic-release-config version

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
