### PR TITLE
f/use-action-setup-tools-before-npm

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,4 @@
 {
-  "extends": ["github>open-turo/renovate-config#v1.21.1"]
+  "extends": ["github>open-turo/renovate-config#v1.21.1"],
+  "ignorePaths": []
 }

--- a/check-build/action.yaml
+++ b/check-build/action.yaml
@@ -7,6 +7,8 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Setup tools
+      uses: open-turo/action-setup-tools@v3
     - name: Run ci
       shell: bash
       run: npm ci

--- a/docs/breaking-changes/v3.md
+++ b/docs/breaking-changes/v3.md
@@ -1,0 +1,17 @@
+# Breaking changes in v3
+
+## `lint`: `node-version` input removed
+
+The `lint` action no longer accepts a `node-version` input. It previously
+installed Node via `actions/setup-node@v7` using this input (default `24`).
+
+It now installs tooling via
+[`open-turo/action-setup-tools@v3`](https://github.com/open-turo/action-setup-tools),
+which reads the Node version from a `.node-version` (or `.nvmrc`) file in the
+root of the consumer repository instead of an explicit input.
+
+### Migration
+
+- Remove any `node-version` input passed to `open-turo/actions-gha/lint`.
+- Add a `.node-version` (or `.nvmrc`) file to the root of the consumer
+  repository specifying the desired Node version.

--- a/lint/README.md
+++ b/lint/README.md
@@ -43,7 +43,6 @@ This action runs the following lint checks:
 | --- | --- | --- | --- |
 | checkout-repo | Perform checkout as first step of action | `false` | true |
 | github-token | GitHub token that can create/delete comments. Usually - 'secrets.GITHUB_TOKEN' | `true` |  |
-| node-version | Node version to use | `false` | 18 |
 | semantic-release-extra-plugins | Extra plugins for pre-install when linting the release notes. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config. | `false` | @open-turo/semantic-release-config  |
 <!-- action-docs-inputs -->
 

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -8,10 +8,6 @@ inputs:
   github-token:
     required: true
     description: GitHub token that can create/delete comments. Usually - 'secrets.GITHUB_TOKEN'
-  node-version:
-    required: false
-    description: Node version to use
-    default: "24"
   semantic-release-extra-plugins:
     required: false
     description: Extra plugins for pre-install when linting the release notes. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.
@@ -25,9 +21,8 @@ runs:
       if: inputs.checkout-repo == 'true'
       with:
         fetch-depth: 0
-    - uses: actions/setup-node@v7
-      with:
-        node-version: ${{ inputs.node-version }}
+    - name: Setup tools
+      uses: open-turo/action-setup-tools@v3
     - name: Run npm ci if needed
       if: hashFiles('package-lock.json') != ''
       shell: bash

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -14,6 +14,9 @@ runs:
     - name: Checkout
       uses: actions/checkout@v7
       if: inputs.checkout-repo == 'true'
+    - name: Setup tools
+      if: hashFiles('package-lock.json') != ''
+      uses: open-turo/action-setup-tools@v3
     - name: Test node
       if: hashFiles('package-lock.json') != ''
       shell: bash

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -12,7 +12,7 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       if: inputs.checkout-repo == 'true'
     - name: Test node
       if: hashFiles('package-lock.json') != ''


### PR DESCRIPTION
**Summary**

<!-- fotingo:start summary -->
Install correct Node version via action-setup-tools before npm; fix renovate test action detection
<!-- fotingo:end summary -->

**Description**

<!-- fotingo:start description -->
Why: npm commands in the test and check-build actions ran with whatever
Node the runner happened to have, and renovate silently ignored the
test action's dependencies (its ignorePaths default excludes
**/test/**), leaving actions/checkout stale there.

What changed:
- test, check-build: call open-turo/action-setup-tools@v3 before any
  npm command so the Node version from the consumer repo's
  .node-version/.nvmrc is installed.
- lint: replace actions/setup-node@v7 with
  open-turo/action-setup-tools@v3 for consistency. BREAKING: removes
  the node-version input, see docs/breaking-changes/v3.md.
- .github/renovate.json: unignore test/ so renovate tracks it.
- test: bump actions/checkout to v7.
<!-- fotingo:end description -->

<!-- fotingo:start fixed-issues -->
<!-- fotingo:end fixed-issues -->

<!-- fotingo:start stacked-prs -->
<!-- fotingo:end stacked-prs -->

**Changes**

<!-- fotingo:start changes -->
* fix(renovate): stop ignoring test/ so renovate tracks its dependencies (+2/-1)
* chore(deps): update actions/checkout action to v7 in test action (+1/-1)
* feat(test,check-build): call action-setup-tools before running npm commands (+5/-0)
* feat(lint)!: replace setup-node with action-setup-tools (+19/-8)
<!-- fotingo:end changes -->

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)